### PR TITLE
Fixing condition on when to start the ticker

### DIFF
--- a/jwt/store.go
+++ b/jwt/store.go
@@ -75,7 +75,7 @@ func NewKeyStore(issuer string, tokenTTL time.Duration, keyTTL *time.Duration, k
 		return nil, err
 	}
 
-	if ks.keyTTL != nil {
+	if ks.ticker != nil {
 		go func() {
 			for range ks.ticker.C {
 				if err := generateNewKey(ks, keyBitSize); err != nil {


### PR DESCRIPTION
Cleaner to check if the ticker is not nil before calling it instead of the keyTTL.